### PR TITLE
add slice.Reject and slice.Partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 
 # go-functional
 Functional programming like interfaces for Go.
+
+Parts of this library were written with the assistance of [Claude Code](https://claude.ai/code).

--- a/slice/partition.go
+++ b/slice/partition.go
@@ -1,0 +1,33 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice
+
+// Partition splits in into two slices in a single pass: the first return value
+// contains elements for which matchFn returns true, the second contains the rest.
+// It is equivalent to calling Filter and Reject together without iterating twice.
+func Partition[T any](in []T, matchFn MatchFn[T]) ([]T, []T) {
+	matches := make([]T, 0, len(in))
+	rejects := make([]T, 0, len(in))
+	for _, e := range in {
+		if matchFn(e) {
+			matches = append(matches, e)
+		} else {
+			rejects = append(rejects, e)
+		}
+	}
+	return matches, rejects
+}

--- a/slice/partition_test.go
+++ b/slice/partition_test.go
@@ -1,0 +1,88 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/slice"
+)
+
+func TestPartition(t *testing.T) {
+	t.Parallel()
+
+	isEven := func(x int) bool { return x%2 == 0 }
+
+	cases := []struct {
+		name        string
+		in          []int
+		wantMatches []int
+		wantRejects []int
+	}{
+		{
+			name:        "empty",
+			in:          []int{},
+			wantMatches: []int{},
+			wantRejects: []int{},
+		},
+		{
+			name:        "all_match",
+			in:          []int{2, 4, 6},
+			wantMatches: []int{2, 4, 6},
+			wantRejects: []int{},
+		},
+		{
+			name:        "none_match",
+			in:          []int{1, 3, 5},
+			wantMatches: []int{},
+			wantRejects: []int{1, 3, 5},
+		},
+		{
+			name:        "partial_match",
+			in:          []int{1, 2, 3, 4, 5},
+			wantMatches: []int{2, 4},
+			wantRejects: []int{1, 3, 5},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotMatches, gotRejects := slice.Partition(tc.in, isEven)
+			if diff := cmp.Diff(tc.wantMatches, gotMatches); diff != "" {
+				t.Fatalf("matches mismatch (-want, +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.wantRejects, gotRejects); diff != "" {
+				t.Fatalf("rejects mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExamplePartition() {
+	isEven := func(x int) bool { return x%2 == 0 }
+	in := []int{1, 2, 3, 4, 5, 6}
+	evens, odds := slice.Partition(in, isEven)
+	fmt.Printf("Evens: %v\n", evens)
+	fmt.Printf("Odds:  %v\n", odds)
+	// Output:
+	// Evens: [2 4 6]
+	// Odds:  [1 3 5]
+}

--- a/slice/reject.go
+++ b/slice/reject.go
@@ -1,0 +1,29 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice
+
+// Reject returns a new slice of only the elements in the list
+// that do NOT match the provided matchFn. It is the complement of Filter.
+func Reject[T any](in []T, matchFn MatchFn[T]) []T {
+	rtn := make([]T, 0, len(in))
+	for _, e := range in {
+		if !matchFn(e) {
+			rtn = append(rtn, e)
+		}
+	}
+	return rtn
+}

--- a/slice/reject_test.go
+++ b/slice/reject_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/slice"
+)
+
+func TestReject(t *testing.T) {
+	t.Parallel()
+
+	isEven := func(x int) bool { return x%2 == 0 }
+
+	cases := []struct {
+		name string
+		in   []int
+		want []int
+	}{
+		{
+			name: "empty",
+			in:   []int{},
+			want: []int{},
+		},
+		{
+			name: "all_match",
+			in:   []int{2, 4, 6},
+			want: []int{},
+		},
+		{
+			name: "none_match",
+			in:   []int{1, 3, 5},
+			want: []int{1, 3, 5},
+		},
+		{
+			name: "partial_match",
+			in:   []int{1, 2, 3, 4, 5},
+			want: []int{1, 3, 5},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.Reject(tc.in, isEven)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleReject() {
+	isEven := func(x int) bool { return x%2 == 0 }
+	in := []int{1, 2, 3, 4, 5, 6}
+	odds := slice.Reject(in, isEven)
+	fmt.Printf("Reject evens from %v: %v\n", in, odds)
+	// Output:
+	// Reject evens from [1 2 3 4 5 6]: [1 3 5]
+}


### PR DESCRIPTION
Fixes #

## Proposed Changes

- `slice.Reject` — complement of `Filter`; returns elements that do **not** match the predicate
- `slice.Partition` — splits a slice into `(matches, rejects)` in a single pass, equivalent to calling `Filter` and `Reject` together without iterating twice
- Both reuse the existing `MatchFn[T]` type from `matchers.go`
- Table-driven unit tests + `Example*` functions for both
- README acknowledgment that parts of the library are written with Claude Code assistance

## Release Note

Add `slice.Reject` and `slice.Partition` as companions to `slice.Filter`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)