### PR TITLE
update CI to current Go version and action versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,11 +22,11 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
 
       - name: Download modules
         run: go mod download
@@ -52,22 +52,16 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: reviewdog/action-setup@v1
 
       - name: Install pcregrep
         run: sudo apt-get -yqq install pcregrep
 
-      - name: Install Protoc
-        run: |-
-          curl -sfLo ${RUNNER_TEMP}/protoc.zip https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protoc-21.4-linux-x86_64.zip
-          unzip ${RUNNER_TEMP}/protoc.zip -d ${RUNNER_TEMP}/protoc
-          echo "${RUNNER_TEMP}/protoc/bin" >> ${GITHUB_PATH}
-
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: '1.20'
+          go-version-file: 'go.mod'
 
       - name: Download modules
         run: go mod download
@@ -78,21 +72,6 @@ jobs:
           set -eEu
           set +o pipefail
           make lint
-
-      - name: zapw-logger
-        shell: bash
-        env:
-          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
-        run: |-
-          set -eEu
-          set +o pipefail
-          make zapcheck 2>&1 | \
-          reviewdog -efm="%f:%l:%c: %m" \
-            -name="zap-logger" \
-            -reporter="github-pr-check" \
-            -filter-mode="diff_context" \
-            -fail-on-error="true" \
-            -level="error"
 
       - name: copyright-check
         shell: bash


### PR DESCRIPTION
## Proposed Changes

- Switch from hardcoded `go-version: '1.20'` to `go-version-file: 'go.mod'` — CI version now stays in sync with the module automatically
- `actions/checkout` v3 → v4
- `actions/setup-go` v3 → v5 (enables Go module cache by default)
- Remove **Install Protoc** step — this repo has no `.proto` files; this was dead weight from a project template
- Remove **zapw-logger** step — this library has no zap logging; the check always passes vacuously

## Release Note

NONE