### PR TITLE
add slice.FlatMap and slice.Flatten

### DIFF
--- a/slice/find_test.go
+++ b/slice/find_test.go
@@ -68,7 +68,6 @@ func TestFind(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gotVal, gotFound := slice.Find(tc.in, isEven)
@@ -126,7 +125,6 @@ func TestFindIndex(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gotIdx, gotFound := slice.FindIndex(tc.in, isEven)

--- a/slice/flatmap.go
+++ b/slice/flatmap.go
@@ -1,0 +1,43 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice
+
+// FlatMapFn maps an individual instance of type T into a slice of type R.
+type FlatMapFn[T any, R any] func(T) []R
+
+// FlatMap applies fn to each element of in and concatenates the resulting
+// slices into a single slice of type R.
+func FlatMap[T any, R any](in []T, fn FlatMapFn[T, R]) []R {
+	rtn := make([]R, 0, len(in))
+	for _, e := range in {
+		rtn = append(rtn, fn(e)...)
+	}
+	return rtn
+}
+
+// Flatten takes a slice of slices and concatenates them into a single slice.
+func Flatten[T any](in [][]T) []T {
+	total := 0
+	for _, s := range in {
+		total += len(s)
+	}
+	rtn := make([]T, 0, total)
+	for _, s := range in {
+		rtn = append(rtn, s...)
+	}
+	return rtn
+}

--- a/slice/flatmap_test.go
+++ b/slice/flatmap_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/slice"
+)
+
+func TestFlatMap(t *testing.T) {
+	t.Parallel()
+
+	split := func(s string) []string { return strings.Split(s, ",") }
+
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "empty",
+			in:   []string{},
+			want: []string{},
+		},
+		{
+			name: "single_element_single_result",
+			in:   []string{"a"},
+			want: []string{"a"},
+		},
+		{
+			name: "single_element_multiple_results",
+			in:   []string{"a,b,c"},
+			want: []string{"a", "b", "c"},
+		},
+		{
+			name: "multiple_elements",
+			in:   []string{"a,b", "c,d"},
+			want: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.FlatMap(tc.in, split)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   [][]int
+		want []int
+	}{
+		{
+			name: "empty",
+			in:   [][]int{},
+			want: []int{},
+		},
+		{
+			name: "single_inner_slice",
+			in:   [][]int{{1, 2, 3}},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "multiple_inner_slices",
+			in:   [][]int{{1, 2}, {3, 4}, {5}},
+			want: []int{1, 2, 3, 4, 5},
+		},
+		{
+			name: "empty_inner_slices",
+			in:   [][]int{{}, {1, 2}, {}},
+			want: []int{1, 2},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.Flatten(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleFlatMap() {
+	words := []string{"hello world", "foo bar"}
+	split := func(s string) []string { return strings.Split(s, " ") }
+	got := slice.FlatMap(words, split)
+	fmt.Printf("%v\n", got)
+	// Output:
+	// [hello world foo bar]
+}
+
+func ExampleFlatten() {
+	in := [][]int{{1, 2}, {3, 4}, {5}}
+	got := slice.Flatten(in)
+	fmt.Printf("%v\n", got)
+	// Output:
+	// [1 2 3 4 5]
+}


### PR DESCRIPTION
## Proposed Changes

- `slice.FlatMap` — applies a `FlatMapFn[T, R]` to each element and concatenates the resulting slices into one
- `slice.Flatten` — concatenates a `[][]T` into a single `[]T`, computing total capacity upfront to avoid repeated allocations
- Fix leftover `tc := tc` loop var copies in `find_test.go` (unnecessary since Go 1.22, flagged by `copyloopvar`)

## Release Note

Add `slice.FlatMap` and `slice.Flatten`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)