### PR TITLE
add slice.ChunkEvery and slice.ChunkBy

### DIFF
--- a/slice/chunk.go
+++ b/slice/chunk.go
@@ -1,0 +1,55 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice
+
+// ChunkEvery splits in into consecutive non-overlapping chunks of size n.
+// The final chunk may be smaller than n if len(in) is not evenly divisible.
+// Returns an empty slice if n <= 0 or in is empty.
+func ChunkEvery[T any](in []T, n int) [][]T {
+	if n <= 0 || len(in) == 0 {
+		return [][]T{}
+	}
+	numChunks := (len(in) + n - 1) / n
+	rtn := make([][]T, 0, numChunks)
+	for i := 0; i < len(in); i += n {
+		end := min(i+n, len(in))
+		rtn = append(rtn, in[i:end])
+	}
+	return rtn
+}
+
+// ChunkBy splits in into consecutive chunks where all elements in a chunk
+// return the same key according to keyFn. A new chunk begins each time the
+// key changes.
+func ChunkBy[T any, K comparable](in []T, keyFn KeyFn[T, K]) [][]T {
+	if len(in) == 0 {
+		return [][]T{}
+	}
+	rtn := make([][]T, 0)
+	start := 0
+	currentKey := keyFn(in[0])
+	for i := 1; i < len(in); i++ {
+		k := keyFn(in[i])
+		if k != currentKey {
+			rtn = append(rtn, in[start:i])
+			start = i
+			currentKey = k
+		}
+	}
+	rtn = append(rtn, in[start:])
+	return rtn
+}

--- a/slice/chunk_test.go
+++ b/slice/chunk_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/slice"
+)
+
+func TestChunkEvery(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []int
+		n    int
+		want [][]int
+	}{
+		{
+			name: "empty",
+			in:   []int{},
+			n:    2,
+			want: [][]int{},
+		},
+		{
+			name: "zero_size",
+			in:   []int{1, 2, 3},
+			n:    0,
+			want: [][]int{},
+		},
+		{
+			name: "negative_size",
+			in:   []int{1, 2, 3},
+			n:    -1,
+			want: [][]int{},
+		},
+		{
+			name: "even_chunks",
+			in:   []int{1, 2, 3, 4},
+			n:    2,
+			want: [][]int{{1, 2}, {3, 4}},
+		},
+		{
+			name: "uneven_chunks",
+			in:   []int{1, 2, 3, 4, 5},
+			n:    2,
+			want: [][]int{{1, 2}, {3, 4}, {5}},
+		},
+		{
+			name: "chunk_larger_than_input",
+			in:   []int{1, 2},
+			n:    5,
+			want: [][]int{{1, 2}},
+		},
+		{
+			name: "chunk_size_one",
+			in:   []int{1, 2, 3},
+			n:    1,
+			want: [][]int{{1}, {2}, {3}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.ChunkEvery(tc.in, tc.n)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestChunkBy(t *testing.T) {
+	t.Parallel()
+
+	isEven := func(x int) bool { return x%2 == 0 }
+
+	cases := []struct {
+		name string
+		in   []int
+		want [][]int
+	}{
+		{
+			name: "empty",
+			in:   []int{},
+			want: [][]int{},
+		},
+		{
+			name: "all_same_key",
+			in:   []int{2, 4, 6},
+			want: [][]int{{2, 4, 6}},
+		},
+		{
+			name: "alternating",
+			in:   []int{1, 2, 3, 4},
+			want: [][]int{{1}, {2}, {3}, {4}},
+		},
+		{
+			name: "consecutive_groups",
+			in:   []int{1, 3, 2, 4, 5},
+			want: [][]int{{1, 3}, {2, 4}, {5}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.ChunkBy(tc.in, isEven)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleChunkEvery() {
+	in := []int{1, 2, 3, 4, 5}
+	fmt.Printf("%v\n", slice.ChunkEvery(in, 2))
+	// Output:
+	// [[1 2] [3 4] [5]]
+}
+
+func ExampleChunkBy() {
+	in := []int{1, 3, 2, 4, 5}
+	isEven := func(x int) bool { return x%2 == 0 }
+	fmt.Printf("%v\n", slice.ChunkBy(in, isEven))
+	// Output:
+	// [[1 3] [2 4] [5]]
+}


### PR DESCRIPTION
## Proposed Changes

- `slice.ChunkEvery` — splits a slice into consecutive chunks of size `n`; the final chunk contains the remainder if the length is not evenly divisible. Returns empty for `n <= 0` or empty input.
- `slice.ChunkBy` — splits into consecutive chunks of elements sharing the same key, starting a new chunk each time the key changes. Reuses the existing `KeyFn[T, K]` type from `frequencies.go`.

## Release Note

Add `slice.ChunkEvery` and `slice.ChunkBy`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)