### PR TITLE
add slice.Scan

### DIFF
--- a/slice/scan.go
+++ b/slice/scan.go
@@ -1,0 +1,30 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice
+
+// Scan is like FoldL but returns a slice of all intermediate accumulator
+// values, including the initial value. The result always has len(in)+1
+// elements, with the first element being the initial accumulator.
+func Scan[T any, A any](in []T, acc A, fn AccFn[T, A]) []A {
+	rtn := make([]A, len(in)+1)
+	rtn[0] = acc
+	for i, v := range in {
+		acc = fn(v, acc)
+		rtn[i+1] = acc
+	}
+	return rtn
+}

--- a/slice/scan_test.go
+++ b/slice/scan_test.go
@@ -1,0 +1,75 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package slice_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/slice"
+)
+
+func TestScan(t *testing.T) {
+	t.Parallel()
+
+	sum := func(v, acc int) int { return acc + v }
+
+	cases := []struct {
+		name string
+		in   []int
+		acc  int
+		want []int
+	}{
+		{
+			name: "empty",
+			in:   []int{},
+			acc:  0,
+			want: []int{0},
+		},
+		{
+			name: "running_sum",
+			in:   []int{1, 2, 3, 4},
+			acc:  0,
+			want: []int{0, 1, 3, 6, 10},
+		},
+		{
+			name: "non_zero_initial",
+			in:   []int{1, 2, 3},
+			acc:  10,
+			want: []int{10, 11, 13, 16},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := slice.Scan(tc.in, tc.acc, sum)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleScan() {
+	in := []int{1, 2, 3, 4, 5}
+	sums := slice.Scan(in, 0, func(v, acc int) int { return acc + v })
+	fmt.Printf("%v\n", sums)
+	// Output:
+	// [0 1 3 6 10 15]
+}


### PR DESCRIPTION
## Proposed Changes

- `slice.Scan` — like `FoldL` but returns all intermediate accumulator values as a slice rather than just the final result. Output length is always `len(in)+1`, with index 0 holding the initial accumulator. Reuses the existing `AccFn[T, A]` type from `fold.go`.

## Release Note

Add `slice.Scan`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)