### PR TITLE
add maps.MapValues, FilterMap, Merge, MergeWith, and Invert

### DIFF
--- a/maps/filter.go
+++ b/maps/filter.go
@@ -1,0 +1,29 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps
+
+// FilterMap returns a new map containing only the key-value pairs for which
+// fn returns true.
+func FilterMap[K comparable, V any](in map[K]V, fn func(K, V) bool) map[K]V {
+	rtn := make(map[K]V)
+	for k, v := range in {
+		if fn(k, v) {
+			rtn[k] = v
+		}
+	}
+	return rtn
+}

--- a/maps/filter_test.go
+++ b/maps/filter_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/maps"
+)
+
+func TestFilterMap(t *testing.T) {
+	t.Parallel()
+
+	positiveValue := func(_ string, v int) bool { return v > 0 }
+
+	cases := []struct {
+		name string
+		in   map[string]int
+		want map[string]int
+	}{
+		{
+			name: "empty",
+			in:   map[string]int{},
+			want: map[string]int{},
+		},
+		{
+			name: "all_pass",
+			in:   map[string]int{"a": 1, "b": 2},
+			want: map[string]int{"a": 1, "b": 2},
+		},
+		{
+			name: "none_pass",
+			in:   map[string]int{"a": -1, "b": -2},
+			want: map[string]int{},
+		},
+		{
+			name: "partial",
+			in:   map[string]int{"a": 1, "b": -2, "c": 3},
+			want: map[string]int{"a": 1, "c": 3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maps.FilterMap(tc.in, positiveValue)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleFilterMap() {
+	scores := map[string]int{"Alice": 90, "Bob": 45, "Carol": 75}
+	passing := maps.FilterMap(scores, func(_ string, v int) bool { return v >= 60 })
+	fmt.Printf("Alice passing: %v\n", passing["Alice"])
+	fmt.Printf("Bob passing: %v\n", passing["Bob"] != 0)
+	fmt.Printf("Carol passing: %v\n", passing["Carol"])
+	// Output:
+	// Alice passing: 90
+	// Bob passing: false
+	// Carol passing: 75
+}

--- a/maps/invert.go
+++ b/maps/invert.go
@@ -1,0 +1,28 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps
+
+// Invert returns a new map with keys and values swapped. If multiple keys
+// in the input map to the same value, the resulting key will map to one of
+// the original keys non-deterministically.
+func Invert[K comparable, V comparable](in map[K]V) map[V]K {
+	rtn := make(map[V]K, len(in))
+	for k, v := range in {
+		rtn[v] = k
+	}
+	return rtn
+}

--- a/maps/invert_test.go
+++ b/maps/invert_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/maps"
+)
+
+func TestInvert(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   map[string]int
+		want map[int]string
+	}{
+		{
+			name: "empty",
+			in:   map[string]int{},
+			want: map[int]string{},
+		},
+		{
+			name: "unique_values",
+			in:   map[string]int{"a": 1, "b": 2, "c": 3},
+			want: map[int]string{1: "a", 2: "b", 3: "c"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maps.Invert(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleInvert() {
+	codes := map[string]int{"USD": 1, "EUR": 2, "GBP": 3}
+	byCode := maps.Invert(codes)
+	fmt.Printf("%s\n", byCode[1])
+	fmt.Printf("%s\n", byCode[2])
+	// Output:
+	// USD
+	// EUR
+}

--- a/maps/mapvalues.go
+++ b/maps/mapvalues.go
@@ -1,0 +1,27 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps
+
+// MapValues returns a new map with the same keys as in, with each value
+// transformed by fn.
+func MapValues[K comparable, V any, R any](in map[K]V, fn func(V) R) map[K]R {
+	rtn := make(map[K]R, len(in))
+	for k, v := range in {
+		rtn[k] = fn(v)
+	}
+	return rtn
+}

--- a/maps/mapvalues_test.go
+++ b/maps/mapvalues_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/maps"
+)
+
+func TestMapValues(t *testing.T) {
+	t.Parallel()
+
+	double := func(v int) int { return v * 2 }
+
+	cases := []struct {
+		name string
+		in   map[string]int
+		want map[string]int
+	}{
+		{
+			name: "empty",
+			in:   map[string]int{},
+			want: map[string]int{},
+		},
+		{
+			name: "doubles_values",
+			in:   map[string]int{"a": 1, "b": 2, "c": 3},
+			want: map[string]int{"a": 2, "b": 4, "c": 6},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maps.MapValues(tc.in, double)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleMapValues() {
+	prices := map[string]float64{"apple": 1.00, "banana": 0.50}
+	discounted := maps.MapValues(prices, func(v float64) float64 { return v * 0.9 })
+	fmt.Printf("apple: %.2f\n", discounted["apple"])
+	fmt.Printf("banana: %.2f\n", discounted["banana"])
+	// Output:
+	// apple: 0.90
+	// banana: 0.45
+}

--- a/maps/merge.go
+++ b/maps/merge.go
@@ -1,0 +1,44 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps
+
+import "maps"
+
+// Merge combines two maps into a new map. When both maps contain the same
+// key, the value from b takes precedence.
+func Merge[K comparable, V any](a, b map[K]V) map[K]V {
+	rtn := make(map[K]V, len(a)+len(b))
+	maps.Copy(rtn, a)
+	maps.Copy(rtn, b)
+	return rtn
+}
+
+// MergeWith combines two maps into a new map. When both maps contain the
+// same key, fn is called with the values from a and b to produce the
+// merged value.
+func MergeWith[K comparable, V any](a, b map[K]V, fn func(V, V) V) map[K]V {
+	rtn := make(map[K]V, len(a)+len(b))
+	maps.Copy(rtn, a)
+	for k, v := range b {
+		if existing, ok := rtn[k]; ok {
+			rtn[k] = fn(existing, v)
+		} else {
+			rtn[k] = v
+		}
+	}
+	return rtn
+}

--- a/maps/merge_test.go
+++ b/maps/merge_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package maps_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/maps"
+)
+
+func TestMerge(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		a    map[string]int
+		b    map[string]int
+		want map[string]int
+	}{
+		{
+			name: "both_empty",
+			a:    map[string]int{},
+			b:    map[string]int{},
+			want: map[string]int{},
+		},
+		{
+			name: "no_overlap",
+			a:    map[string]int{"a": 1},
+			b:    map[string]int{"b": 2},
+			want: map[string]int{"a": 1, "b": 2},
+		},
+		{
+			name: "b_wins_on_conflict",
+			a:    map[string]int{"a": 1, "b": 2},
+			b:    map[string]int{"b": 99, "c": 3},
+			want: map[string]int{"a": 1, "b": 99, "c": 3},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maps.Merge(tc.a, tc.b)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestMergeWith(t *testing.T) {
+	t.Parallel()
+
+	sum := func(a, b int) int { return a + b }
+
+	cases := []struct {
+		name string
+		a    map[string]int
+		b    map[string]int
+		want map[string]int
+	}{
+		{
+			name: "both_empty",
+			a:    map[string]int{},
+			b:    map[string]int{},
+			want: map[string]int{},
+		},
+		{
+			name: "no_overlap",
+			a:    map[string]int{"a": 1},
+			b:    map[string]int{"b": 2},
+			want: map[string]int{"a": 1, "b": 2},
+		},
+		{
+			name: "conflict_resolved_by_fn",
+			a:    map[string]int{"a": 1, "b": 2},
+			b:    map[string]int{"b": 3, "c": 4},
+			want: map[string]int{"a": 1, "b": 5, "c": 4},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := maps.MergeWith(tc.a, tc.b, sum)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ExampleMerge() {
+	defaults := map[string]int{"timeout": 30, "retries": 3}
+	overrides := map[string]int{"retries": 5, "verbose": 1}
+	config := maps.Merge(defaults, overrides)
+	fmt.Printf("timeout: %d\n", config["timeout"])
+	fmt.Printf("retries: %d\n", config["retries"])
+	fmt.Printf("verbose: %d\n", config["verbose"])
+	// Output:
+	// timeout: 30
+	// retries: 5
+	// verbose: 1
+}
+
+func ExampleMergeWith() {
+	a := map[string]int{"x": 1, "y": 2}
+	b := map[string]int{"y": 3, "z": 4}
+	merged := maps.MergeWith(a, b, func(va, vb int) int { return va + vb })
+	fmt.Printf("x: %d\n", merged["x"])
+	fmt.Printf("y: %d\n", merged["y"])
+	fmt.Printf("z: %d\n", merged["z"])
+	// Output:
+	// x: 1
+	// y: 5
+	// z: 4
+}


### PR DESCRIPTION
## Proposed Changes

- `maps.MapValues` — transforms values while preserving keys; returns a new map
- `maps.FilterMap` — returns a new map with only entries where `fn(k, v)` returns true
- `maps.Merge` — combines two maps; `b` takes precedence on key conflicts
- `maps.MergeWith` — combines two maps using a caller-supplied function to resolve conflicts
- `maps.Invert` — swaps keys and values; requires values to be `comparable`; non-deterministic on duplicate values (documented)
- `Merge` and `MergeWith` use `maps.Copy` from the standard library

## Release Note

Add `maps.MapValues`, `maps.FilterMap`, `maps.Merge`, `maps.MergeWith`, and `maps.Invert`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)