### PR TITLE
add pipeline package with function composition

### DIFF
--- a/pipeline/doc.go
+++ b/pipeline/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipeline provides function composition utilities.
+// Functions are composed left-to-right: the output of each function
+// is passed as the input to the next.
+package pipeline

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,53 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package pipeline
+
+// Pipe composes zero or more same-type functions left-to-right, returning a
+// single function that applies each in sequence. Pipe(f, g, h)(x) == h(g(f(x))).
+// If no functions are provided, Pipe returns the identity function.
+func Pipe[T any](fns ...func(T) T) func(T) T {
+	return func(v T) T {
+		for _, fn := range fns {
+			v = fn(v)
+		}
+		return v
+	}
+}
+
+// Pipe2 composes two functions left-to-right where types may differ.
+// Pipe2(f, g)(x) == g(f(x)).
+func Pipe2[A, B, C any](f func(A) B, g func(B) C) func(A) C {
+	return func(a A) C {
+		return g(f(a))
+	}
+}
+
+// Pipe3 composes three functions left-to-right where types may differ.
+// Pipe3(f, g, h)(x) == h(g(f(x))).
+func Pipe3[A, B, C, D any](f func(A) B, g func(B) C, h func(C) D) func(A) D {
+	return func(a A) D {
+		return h(g(f(a)))
+	}
+}
+
+// Pipe4 composes four functions left-to-right where types may differ.
+// Pipe4(f, g, h, i)(x) == i(h(g(f(x)))).
+func Pipe4[A, B, C, D, E any](f func(A) B, g func(B) C, h func(C) D, i func(D) E) func(A) E {
+	return func(a A) E {
+		return i(h(g(f(a))))
+	}
+}

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package pipeline_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/pipeline"
+)
+
+func TestPipe(t *testing.T) {
+	t.Parallel()
+
+	double := func(x int) int { return x * 2 }
+	addOne := func(x int) int { return x + 1 }
+
+	cases := []struct {
+		name string
+		fns  []func(int) int
+		in   int
+		want int
+	}{
+		{
+			name: "no_functions_identity",
+			fns:  []func(int) int{},
+			in:   42,
+			want: 42,
+		},
+		{
+			name: "single_function",
+			fns:  []func(int) int{double},
+			in:   5,
+			want: 10,
+		},
+		{
+			name: "left_to_right_order",
+			fns:  []func(int) int{double, addOne},
+			in:   5,
+			want: 11, // (5*2)+1
+		},
+		{
+			name: "three_functions",
+			fns:  []func(int) int{addOne, double, addOne},
+			in:   3,
+			want: 9, // ((3+1)*2)+1
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pipeline.Pipe(tc.fns...)(tc.in)
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestPipe2(t *testing.T) {
+	t.Parallel()
+	f := pipeline.Pipe2(
+		func(s string) int { return len(s) },
+		func(n int) bool { return n > 3 },
+	)
+	if diff := cmp.Diff(true, f("hello")); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(false, f("hi")); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestPipe3(t *testing.T) {
+	t.Parallel()
+	f := pipeline.Pipe3(
+		strings.TrimSpace,
+		strings.ToUpper,
+		func(s string) int { return len(s) },
+	)
+	if diff := cmp.Diff(5, f("  hello  ")); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestPipe4(t *testing.T) {
+	t.Parallel()
+	f := pipeline.Pipe4(
+		strings.TrimSpace,
+		strings.ToUpper,
+		func(s string) []string { return strings.Split(s, " ") },
+		func(ss []string) int { return len(ss) },
+	)
+	if diff := cmp.Diff(3, f("  foo bar baz  ")); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func ExamplePipe() {
+	transform := pipeline.Pipe(
+		func(x int) int { return x * 2 },
+		func(x int) int { return x + 1 },
+	)
+	fmt.Println(transform(5))
+	// Output:
+	// 11
+}
+
+func ExamplePipe2() {
+	f := pipeline.Pipe2(
+		strings.TrimSpace,
+		strings.ToUpper,
+	)
+	fmt.Println(f("  hello  "))
+	// Output:
+	// HELLO
+}


### PR DESCRIPTION
## Proposed Changes

New `pipeline` package for left-to-right function composition (Elixir `|>` style).

- `Pipe[T](fns ...func(T) T) func(T) T` — variadic composition for same-type chains; returns identity when given no functions
- `Pipe2[A,B,C]` / `Pipe3[A,B,C,D]` / `Pipe4[A,B,C,D,E]` — typed arities for heterogeneous pipelines where each step may change the type

Go does not support variadic type parameters, so the typed arities (`Pipe2`–`Pipe4`) are provided explicitly for the common cases.

## Release Note

Add `pipeline` package with `Pipe`, `Pipe2`, `Pipe3`, and `Pipe4`.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)