### PR TITLE
add agent package inspired by Elixir OTP Agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,0 +1,112 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package agent
+
+import "sync"
+
+// call is an internal message sent to the agent's loop goroutine.
+type call[S any] struct {
+	// fn transforms the current state and returns (newState, replyValue).
+	fn func(S) (S, any)
+	// replyCh receives the reply value. nil for async calls (Cast).
+	replyCh chan any
+	// stop signals the loop to exit.
+	stop bool
+}
+
+// Agent holds state of type S in a dedicated goroutine. All operations are
+// goroutine-safe and serialized. Methods must not be called after Stop.
+type Agent[S any] struct {
+	callCh   chan call[S]
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// New creates and starts an Agent with the given initial state.
+func New[S any](initial S) *Agent[S] {
+	a := &Agent[S]{
+		callCh: make(chan call[S]),
+		doneCh: make(chan struct{}),
+	}
+	go a.loop(initial)
+	return a
+}
+
+func (a *Agent[S]) loop(state S) {
+	defer close(a.doneCh)
+	for c := range a.callCh {
+		if c.stop {
+			return
+		}
+		newState, reply := c.fn(state)
+		state = newState
+		if c.replyCh != nil {
+			c.replyCh <- reply
+		}
+	}
+}
+
+// Get returns the current state.
+func (a *Agent[S]) Get() S {
+	replyCh := make(chan any, 1)
+	a.callCh <- call[S]{
+		fn:      func(s S) (S, any) { return s, s },
+		replyCh: replyCh,
+	}
+	return (<-replyCh).(S) //nolint:forcetypeassert
+}
+
+// Update applies fn to the current state, stores the result, and blocks
+// until the update is complete.
+func (a *Agent[S]) Update(fn func(S) S) {
+	replyCh := make(chan any, 1)
+	a.callCh <- call[S]{
+		fn:      func(s S) (S, any) { return fn(s), nil },
+		replyCh: replyCh,
+	}
+	<-replyCh
+}
+
+// Cast applies fn to the current state asynchronously. It returns
+// immediately without waiting for the update to complete.
+func (a *Agent[S]) Cast(fn func(S) S) {
+	a.callCh <- call[S]{
+		fn: func(s S) (S, any) { return fn(s), nil },
+	}
+}
+
+// Stop shuts down the agent. It blocks until the loop goroutine exits.
+// Calling Stop more than once is safe; subsequent calls are no-ops.
+func (a *Agent[S]) Stop() {
+	a.stopOnce.Do(func() {
+		a.callCh <- call[S]{stop: true}
+		<-a.doneCh
+	})
+}
+
+// GetWith applies fn to the agent's state and returns the result.
+// Unlike Get, the return type R may differ from the state type S.
+// This is a package-level function because Go methods cannot introduce
+// additional type parameters.
+func GetWith[S, R any](a *Agent[S], fn func(S) R) R {
+	replyCh := make(chan any, 1)
+	a.callCh <- call[S]{
+		fn:      func(s S) (S, any) { return s, fn(s) },
+		replyCh: replyCh,
+	}
+	return (<-replyCh).(R) //nolint:forcetypeassert
+}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,0 +1,119 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package agent_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/agent"
+)
+
+func TestGetReturnsInitialState(t *testing.T) {
+	t.Parallel()
+	a := agent.New(42)
+	defer a.Stop()
+	if diff := cmp.Diff(42, a.Get()); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	t.Parallel()
+	a := agent.New(0)
+	defer a.Stop()
+	a.Update(func(s int) int { return s + 10 })
+	if diff := cmp.Diff(10, a.Get()); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestCast(t *testing.T) {
+	t.Parallel()
+	a := agent.New(0)
+	defer a.Stop()
+	a.Cast(func(s int) int { return s + 1 })
+	// Synchronize by calling Get, which is serialized after Cast.
+	if diff := cmp.Diff(1, a.Get()); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestGetWith(t *testing.T) {
+	t.Parallel()
+	a := agent.New([]string{"hello", "world"})
+	defer a.Stop()
+	length := agent.GetWith(a, func(s []string) int { return len(s) })
+	if diff := cmp.Diff(2, length); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+	a := agent.New(0)
+	a.Stop()
+	a.Stop() // must not panic or deadlock
+}
+
+func TestConcurrentUpdates(t *testing.T) {
+	t.Parallel()
+	a := agent.New(0)
+	defer a.Stop()
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			a.Update(func(s int) int { return s + 1 })
+		}()
+	}
+	wg.Wait()
+
+	if diff := cmp.Diff(100, a.Get()); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func ExampleAgent_Get() {
+	a := agent.New(42)
+	defer a.Stop()
+	fmt.Println(a.Get())
+	// Output:
+	// 42
+}
+
+func ExampleAgent_Update() {
+	a := agent.New(0)
+	defer a.Stop()
+	a.Update(func(s int) int { return s + 10 })
+	fmt.Println(a.Get())
+	// Output:
+	// 10
+}
+
+func ExampleGetWith() {
+	a := agent.New(map[string]int{"a": 1, "b": 2, "c": 3})
+	defer a.Stop()
+	size := agent.GetWith(a, func(m map[string]int) int { return len(m) })
+	fmt.Println(size)
+	// Output:
+	// 3
+}

--- a/agent/doc.go
+++ b/agent/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agent provides a goroutine-safe state container inspired by
+// Elixir's Agent. State is owned by a single goroutine; all access is
+// serialized through channel-based message passing.
+package agent


### PR DESCRIPTION
## Proposed Changes

New `agent` package. `Agent[S]` owns state of type `S` in a dedicated goroutine; all access is serialized through channel-based message passing.

**API:**
| | |
|---|---|
| `New(initial S) *Agent[S]` | start with initial state |
| `Get() S` | synchronous state read |
| `Update(func(S) S)` | synchronous state transform, blocks until complete |
| `Cast(func(S) S)` | async state transform, returns immediately |
| `Stop()` | shut down the agent; idempotent, safe to call multiple times |
| `GetWith[S,R](a, func(S) R) R` | project state to a different type |

`GetWith` is a package-level function because Go methods cannot introduce additional type parameters.

The concurrent update test validates 100 parallel increments produce the correct result under the `-race` detector.

## Release Note

Add `agent` package with `Agent[S]` type inspired by Elixir OTP Agent.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)