### PR TITLE
add genserver package inspired by Elixir OTP GenServer

### DIFF
--- a/genserver/doc.go
+++ b/genserver/doc.go
@@ -1,0 +1,25 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package genserver provides a generic server process inspired by Elixir's
+// OTP GenServer. State is owned by a single goroutine; Call and Cast
+// messages are serialized through a single channel to preserve ordering.
+//
+// Call is synchronous: the caller blocks until HandleCall returns a response.
+// Cast is asynchronous: the caller returns immediately after sending.
+//
+// Without tail-call optimization in Go, the server loop is an explicit
+// channel select rather than a recursive function, but the semantics are
+// equivalent.
+package genserver

--- a/genserver/genserver.go
+++ b/genserver/genserver.go
@@ -1,0 +1,98 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package genserver
+
+import "sync"
+
+// Server defines the callbacks for a GenServer process.
+// S is the state type, Req is the request/message type, and Resp is the
+// response type returned by synchronous calls.
+type Server[S, Req, Resp any] interface {
+	// Init returns the initial state of the server.
+	Init() S
+	// HandleCall processes a synchronous request. It returns a response
+	// sent back to the caller and the updated state.
+	HandleCall(req Req, state S) (Resp, S)
+	// HandleCast processes an asynchronous message. It returns the
+	// updated state. No response is sent to the caller.
+	HandleCast(msg Req, state S) S
+}
+
+// msg is an internal envelope used by the server loop.
+type msg[Req, Resp any] struct {
+	req     Req
+	replyCh chan Resp // nil for Cast; non-nil for Call
+	stop    bool
+}
+
+// GenServer is a running server process. All operations are goroutine-safe.
+// Methods must not be called after Stop.
+type GenServer[S, Req, Resp any] struct {
+	msgCh    chan msg[Req, Resp]
+	doneCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// Start initialises the server by calling srv.Init() and launches the
+// message loop in a new goroutine.
+func Start[S, Req, Resp any](srv Server[S, Req, Resp]) *GenServer[S, Req, Resp] {
+	g := &GenServer[S, Req, Resp]{
+		msgCh:  make(chan msg[Req, Resp]),
+		doneCh: make(chan struct{}),
+	}
+	go g.loop(srv, srv.Init())
+	return g
+}
+
+func (g *GenServer[S, Req, Resp]) loop(srv Server[S, Req, Resp], state S) {
+	defer close(g.doneCh)
+	for m := range g.msgCh {
+		if m.stop {
+			return
+		}
+		if m.replyCh != nil {
+			resp, newState := srv.HandleCall(m.req, state)
+			state = newState
+			m.replyCh <- resp
+		} else {
+			state = srv.HandleCast(m.req, state)
+		}
+	}
+}
+
+// Call sends a synchronous request and blocks until the server returns a
+// response.
+func (g *GenServer[S, Req, Resp]) Call(req Req) Resp {
+	replyCh := make(chan Resp, 1)
+	g.msgCh <- msg[Req, Resp]{req: req, replyCh: replyCh}
+	return <-replyCh
+}
+
+// Cast sends an asynchronous message and returns immediately without
+// waiting for the server to process it.
+func (g *GenServer[S, Req, Resp]) Cast(req Req) {
+	g.msgCh <- msg[Req, Resp]{req: req}
+}
+
+// Stop shuts down the server and blocks until the loop goroutine exits.
+// Calling Stop more than once is safe; subsequent calls are no-ops.
+func (g *GenServer[S, Req, Resp]) Stop() {
+	g.stopOnce.Do(func() {
+		g.msgCh <- msg[Req, Resp]{stop: true}
+		<-g.doneCh
+	})
+}

--- a/genserver/genserver_test.go
+++ b/genserver/genserver_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package genserver_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/genserver"
+)
+
+// --- counter server used across tests ---
+
+type counterCmd int
+
+const (
+	cmdGet counterCmd = iota
+	cmdIncrement
+	cmdAdd
+	cmdReset
+)
+
+type counterReq struct {
+	cmd counterCmd
+	val int
+}
+
+// counterServer is a simple integer counter implementing genserver.Server.
+type counterServer struct{}
+
+func (counterServer) Init() int { return 0 }
+
+func (counterServer) HandleCall(req counterReq, state int) (int, int) {
+	switch req.cmd {
+	case cmdGet:
+		return state, state
+	case cmdIncrement:
+		return state + 1, state + 1
+	case cmdAdd, cmdReset:
+		return state, state
+	}
+	return state, state
+}
+
+func (counterServer) HandleCast(req counterReq, state int) int {
+	switch req.cmd {
+	case cmdAdd:
+		return state + req.val
+	case cmdReset:
+		return 0
+	case cmdGet, cmdIncrement:
+		return state
+	}
+	return state
+}
+
+// --- tests ---
+
+func TestCallGet(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	got := gs.Call(counterReq{cmd: cmdGet})
+	if diff := cmp.Diff(0, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestCallIncrement(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	gs.Call(counterReq{cmd: cmdIncrement})
+	gs.Call(counterReq{cmd: cmdIncrement})
+	got := gs.Call(counterReq{cmd: cmdGet})
+	if diff := cmp.Diff(2, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestCastAdd(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	gs.Cast(counterReq{cmd: cmdAdd, val: 5})
+	gs.Cast(counterReq{cmd: cmdAdd, val: 3})
+	// Call serializes after the casts.
+	got := gs.Call(counterReq{cmd: cmdGet})
+	if diff := cmp.Diff(8, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestCastReset(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	gs.Call(counterReq{cmd: cmdIncrement})
+	gs.Call(counterReq{cmd: cmdIncrement})
+	gs.Cast(counterReq{cmd: cmdReset})
+	got := gs.Call(counterReq{cmd: cmdGet})
+	if diff := cmp.Diff(0, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestStopIsIdempotent(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	gs.Stop()
+	gs.Stop()
+}
+
+func TestConcurrentCalls(t *testing.T) {
+	t.Parallel()
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			gs.Call(counterReq{cmd: cmdIncrement})
+		}()
+	}
+	wg.Wait()
+
+	got := gs.Call(counterReq{cmd: cmdGet})
+	if diff := cmp.Diff(100, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+// --- example ---
+
+func ExampleGenServer_Call() {
+	gs := genserver.Start[int, counterReq, int](counterServer{})
+	defer gs.Stop()
+
+	gs.Cast(counterReq{cmd: cmdAdd, val: 10})
+	gs.Call(counterReq{cmd: cmdIncrement})
+	fmt.Println(gs.Call(counterReq{cmd: cmdGet}))
+	// Output:
+	// 11
+}


### PR DESCRIPTION
## Proposed Changes

New `genserver` package. Implement the `Server[S, Req, Resp]` interface to define a stateful server process:

```go
type Server[S, Req, Resp any] interface {
    Init() S
    HandleCall(req Req, state S) (Resp, S)
    HandleCast(msg Req, state S) S
}
```

`Start[S, Req, Resp](srv)` launches the loop goroutine and returns a `*GenServer` with:
- `Call(req Req) Resp` — synchronous, blocks until `HandleCall` returns
- `Cast(req Req)` — async, returns immediately
- `Stop()` — shuts down the loop; idempotent

**Design notes:**
- `Call` and `Cast` share a **single ordered channel** so interleaved messages are processed in arrival order, matching Elixir GenServer semantics
- Without tail-call optimization in Go, the server loop is an explicit channel `range` rather than a recursive function — semantics are equivalent
- The concurrent call test validates 100 parallel `Call`s under the `-race` detector

## Release Note

Add `genserver` package with `GenServer[S, Req, Resp]` type inspired by Elixir OTP GenServer.

🤖 Parts of this PR were written with [Claude Code](https://claude.ai/code)