### PR TITLE
add task package inspired by Elixir OTP Task

### DIFF
--- a/task/doc.go
+++ b/task/doc.go
@@ -1,0 +1,18 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package task provides typed asynchronous work units inspired by Elixir's
+// Task module. Run starts a function in a goroutine; Await retrieves the
+// result, blocking until it is ready.
+package task

--- a/task/task.go
+++ b/task/task.go
@@ -1,0 +1,95 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package task
+
+import "sync"
+
+type taskResult[T any] struct {
+	value T
+	err   error
+}
+
+// Task represents an asynchronous computation of type T. A Task is safe to
+// Await from multiple goroutines; all callers receive the same result.
+type Task[T any] struct {
+	once   sync.Once
+	ch     chan taskResult[T]
+	result taskResult[T]
+}
+
+// Run starts fn in a new goroutine and returns a Task to retrieve the result.
+func Run[T any](fn func() (T, error)) *Task[T] {
+	t := &Task[T]{ch: make(chan taskResult[T], 1)}
+	go func() {
+		v, err := fn()
+		t.ch <- taskResult[T]{value: v, err: err}
+	}()
+	return t
+}
+
+func (t *Task[T]) await() taskResult[T] {
+	t.once.Do(func() {
+		t.result = <-t.ch
+	})
+	return t.result
+}
+
+// Await blocks until the task is complete and returns the value and any error.
+// It is safe to call Await multiple times or from multiple goroutines.
+func (t *Task[T]) Await() (T, error) {
+	r := t.await()
+	return r.value, r.err
+}
+
+// MustAwait blocks until the task is complete and returns the value.
+// It panics if the task returned an error.
+func (t *Task[T]) MustAwait() T {
+	v, err := t.Await()
+	if err != nil {
+		panic("task: MustAwait called on failed Task: " + err.Error())
+	}
+	return v
+}
+
+// AwaitAll waits for all tasks and returns their values in order.
+// The first error encountered is returned; remaining tasks continue running.
+func AwaitAll[T any](tasks []*Task[T]) ([]T, error) {
+	results := make([]T, len(tasks))
+	for i, t := range tasks {
+		v, err := t.Await()
+		if err != nil {
+			return nil, err
+		}
+		results[i] = v
+	}
+	return results, nil
+}
+
+// Map starts a new Task that applies fn to the result of t when it completes.
+// If t fails, the mapped task propagates the error without calling fn.
+// This is a package-level function because Go methods cannot introduce
+// additional type parameters.
+func Map[T, R any](t *Task[T], fn func(T) R) *Task[R] {
+	return Run(func() (R, error) {
+		v, err := t.Await()
+		if err != nil {
+			var zero R
+			return zero, err
+		}
+		return fn(v), nil
+	})
+}

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,166 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package task_test
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/mikehelmick/go-functional/task"
+)
+
+var errTest = errors.New("task error")
+
+func TestRunAndAwait(t *testing.T) {
+	t.Parallel()
+	got, err := task.Run(func() (int, error) { return 42, nil }).Await()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff(42, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestAwaitError(t *testing.T) {
+	t.Parallel()
+	_, err := task.Run(func() (int, error) { return 0, errTest }).Await()
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected errTest, got %v", err)
+	}
+}
+
+func TestMustAwait(t *testing.T) {
+	t.Parallel()
+	got := task.Run(func() (int, error) { return 7, nil }).MustAwait()
+	if diff := cmp.Diff(7, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestMustAwaitPanicsOnError(t *testing.T) {
+	t.Parallel()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("expected panic on MustAwait of failed task")
+		}
+	}()
+	task.Run(func() (int, error) { return 0, errTest }).MustAwait()
+}
+
+func TestAwaitIdempotent(t *testing.T) {
+	t.Parallel()
+	tsk := task.Run(func() (int, error) { return 99, nil })
+	for range 5 {
+		got, err := tsk.Await()
+		if err != nil || got != 99 {
+			t.Fatalf("expected 99/nil, got %v/%v", got, err)
+		}
+	}
+}
+
+func TestAwaitConcurrent(t *testing.T) {
+	t.Parallel()
+	tsk := task.Run(func() (int, error) { return 42, nil })
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := tsk.Await()
+			if err != nil || got != 42 {
+				t.Errorf("expected 42/nil, got %v/%v", got, err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestAwaitAll(t *testing.T) {
+	t.Parallel()
+	tasks := []*task.Task[int]{
+		task.Run(func() (int, error) { return 1, nil }),
+		task.Run(func() (int, error) { return 2, nil }),
+		task.Run(func() (int, error) { return 3, nil }),
+	}
+	got, err := task.AwaitAll(tasks)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff([]int{1, 2, 3}, got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestAwaitAllError(t *testing.T) {
+	t.Parallel()
+	tasks := []*task.Task[int]{
+		task.Run(func() (int, error) { return 1, nil }),
+		task.Run(func() (int, error) { return 0, errTest }),
+		task.Run(func() (int, error) { return 3, nil }),
+	}
+	_, err := task.AwaitAll(tasks)
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected errTest, got %v", err)
+	}
+}
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+	tsk := task.Run(func() (int, error) { return 21, nil })
+	mapped := task.Map(tsk, func(v int) string { return fmt.Sprintf("%d", v*2) })
+	got, err := mapped.Await()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if diff := cmp.Diff("42", got); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+}
+
+func TestMapPropagatesError(t *testing.T) {
+	t.Parallel()
+	tsk := task.Run(func() (int, error) { return 0, errTest })
+	mapped := task.Map(tsk, func(v int) string { return fmt.Sprintf("%d", v) })
+	_, err := mapped.Await()
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected errTest to propagate, got %v", err)
+	}
+}
+
+func ExampleRun() {
+	t := task.Run(func() (int, error) { return 42, nil })
+	v, _ := t.Await()
+	fmt.Println(v)
+	// Output:
+	// 42
+}
+
+func ExampleAwaitAll() {
+	tasks := []*task.Task[int]{
+		task.Run(func() (int, error) { return 1, nil }),
+		task.Run(func() (int, error) { return 2, nil }),
+		task.Run(func() (int, error) { return 3, nil }),
+	}
+	results, _ := task.AwaitAll(tasks)
+	fmt.Println(results)
+	// Output:
+	// [1 2 3]
+}


### PR DESCRIPTION
## Summary

- Adds `task` package with `Run`, `Await`, `MustAwait`, `AwaitAll`, and `Map`
- `Task[T]` runs a function in a goroutine; result is safely retrievable from multiple goroutines via `sync.Once`
- `AwaitAll` collects results in order, returning the first error encountered
- `Map` transforms a task's result into a new type without calling the function on error

## Test plan

- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] `make test-acc` (race detector) passes

🤖 Generated with [Claude Code](https://claude.ai/code)