### PR TITLE
add supervisor package inspired by Elixir OTP Supervisor

### DIFF
--- a/supervisor/doc.go
+++ b/supervisor/doc.go
@@ -1,0 +1,24 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+// Package supervisor provides a supervised goroutine manager inspired by
+// Elixir's OTP Supervisor. Workers are restarted automatically on failure
+// according to the chosen Strategy.
+//
+// A worker function signals a clean exit by returning nil; returning a
+// non-nil error triggers a restart. Workers should honour context
+// cancellation so the supervisor can shut down cleanly.
+package supervisor

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -1,0 +1,146 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package supervisor
+
+import (
+	"context"
+	"sync"
+)
+
+// Strategy controls how the supervisor responds to a child failure.
+type Strategy int
+
+const (
+	// OneForOne restarts only the child that failed, leaving others running.
+	OneForOne Strategy = iota
+	// OneForAll restarts all children when any one of them fails.
+	OneForAll
+)
+
+// ChildSpec defines a supervised worker. Start runs in its own goroutine.
+// A nil return signals a clean exit (no restart). A non-nil return signals
+// a crash and triggers a restart according to the supervisor's Strategy.
+// Start must honour context cancellation to allow clean shutdown.
+type ChildSpec struct {
+	Name  string
+	Start func(ctx context.Context) error
+}
+
+type exitMsg struct {
+	idx int
+	err error
+}
+
+// Supervisor manages a set of worker goroutines with automatic restart.
+// All methods are safe to call from multiple goroutines.
+// Methods must not be called after Stop.
+type Supervisor struct {
+	strategy Strategy
+	specs    []ChildSpec
+	stopCh   chan struct{}
+	stopped  chan struct{}
+	stopOnce sync.Once
+}
+
+// Start launches the supervisor and all children immediately.
+func Start(strategy Strategy, specs []ChildSpec) *Supervisor {
+	s := &Supervisor{
+		strategy: strategy,
+		specs:    specs,
+		stopCh:   make(chan struct{}),
+		stopped:  make(chan struct{}),
+	}
+	go s.loop()
+	return s
+}
+
+func (s *Supervisor) loop() {
+	defer close(s.stopped)
+
+	exitCh := make(chan exitMsg, len(s.specs))
+	ctx, cancel := s.startAll(exitCh)
+
+	alive := len(s.specs)
+	for alive > 0 {
+		select {
+		case <-s.stopCh:
+			cancel()
+			for alive > 0 {
+				<-exitCh
+				alive--
+			}
+			return
+		case exit := <-exitCh:
+			alive--
+			if exit.err == nil {
+				// Clean exit — do not restart.
+				continue
+			}
+			// Crashed — check if we are already shutting down.
+			select {
+			case <-s.stopCh:
+				cancel()
+				for alive > 0 {
+					<-exitCh
+					alive--
+				}
+				return
+			default:
+			}
+			switch s.strategy {
+			case OneForOne:
+				alive++
+				go s.runChild(ctx, exit.idx, exitCh)
+			case OneForAll:
+				// Cancel context to stop all running children, drain their
+				// exits, then restart every child with a fresh context.
+				cancel()
+				for alive > 0 {
+					<-exitCh
+					alive--
+				}
+				ctx, cancel = s.startAll(exitCh)
+				alive = len(s.specs)
+			}
+		}
+	}
+	cancel()
+}
+
+// startAll creates a fresh context, launches all children, and returns the
+// context and its cancel function. The caller is responsible for calling cancel.
+func (s *Supervisor) startAll(exitCh chan exitMsg) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
+	for i := range s.specs {
+		go s.runChild(ctx, i, exitCh)
+	}
+	return ctx, cancel
+}
+
+func (s *Supervisor) runChild(ctx context.Context, idx int, exitCh chan<- exitMsg) {
+	err := s.specs[idx].Start(ctx)
+	exitCh <- exitMsg{idx: idx, err: err}
+}
+
+// Stop cancels all children and blocks until the supervisor loop exits.
+// Calling Stop more than once is safe; subsequent calls are no-ops.
+func (s *Supervisor) Stop() {
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+		<-s.stopped
+	})
+}

--- a/supervisor/supervisor_test.go
+++ b/supervisor/supervisor_test.go
@@ -1,0 +1,244 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+package supervisor_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mikehelmick/go-functional/supervisor"
+)
+
+var errCrash = errors.New("crash")
+
+func TestOneForOneRestartsCrashedChild(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	restartedCh := make(chan struct{})
+
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "crasher",
+			Start: func(ctx context.Context) error {
+				if count.Add(1) == 1 {
+					return errCrash
+				}
+				close(restartedCh)
+				<-ctx.Done()
+				return nil
+			},
+		},
+	}
+
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	select {
+	case <-restartedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for restart")
+	}
+	sup.Stop()
+
+	if count.Load() < 2 {
+		t.Errorf("expected at least 2 starts, got %d", count.Load())
+	}
+}
+
+func TestOneForOneOnlyRestartsCrashedChild(t *testing.T) {
+	t.Parallel()
+
+	var counts [2]atomic.Int32
+	crasherRestartedCh := make(chan struct{})
+
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "crasher",
+			Start: func(ctx context.Context) error {
+				if counts[0].Add(1) == 1 {
+					return errCrash
+				}
+				close(crasherRestartedCh)
+				<-ctx.Done()
+				return nil
+			},
+		},
+		{
+			Name: "stable",
+			Start: func(ctx context.Context) error {
+				counts[1].Add(1)
+				<-ctx.Done()
+				return nil
+			},
+		},
+	}
+
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	select {
+	case <-crasherRestartedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for crasher restart")
+	}
+	sup.Stop()
+
+	if counts[0].Load() < 2 {
+		t.Errorf("crasher: expected at least 2 starts, got %d", counts[0].Load())
+	}
+	if counts[1].Load() != 1 {
+		t.Errorf("stable: expected exactly 1 start, got %d", counts[1].Load())
+	}
+}
+
+func TestOneForAllRestartsAllOnCrash(t *testing.T) {
+	t.Parallel()
+
+	var counts [2]atomic.Int32
+	// closed when both children have been started a second time
+	bothRestartedCh := make(chan struct{})
+	var closeOnce atomic.Bool
+
+	makeSpec := func(idx int) supervisor.ChildSpec {
+		return supervisor.ChildSpec{
+			Name: fmt.Sprintf("child-%d", idx),
+			Start: func(ctx context.Context) error {
+				n := counts[idx].Add(1)
+				if idx == 0 && n == 1 {
+					return errCrash // first child crashes on its first run
+				}
+				// Signal when both are on their second run.
+				if counts[0].Load() >= 2 && counts[1].Load() >= 2 {
+					if closeOnce.CompareAndSwap(false, true) {
+						close(bothRestartedCh)
+					}
+				}
+				<-ctx.Done()
+				return nil
+			},
+		}
+	}
+
+	specs := []supervisor.ChildSpec{makeSpec(0), makeSpec(1)}
+	sup := supervisor.Start(supervisor.OneForAll, specs)
+
+	select {
+	case <-bothRestartedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for all children to restart")
+	}
+	sup.Stop()
+
+	if counts[0].Load() < 2 {
+		t.Errorf("child-0: expected at least 2 starts, got %d", counts[0].Load())
+	}
+	if counts[1].Load() < 2 {
+		t.Errorf("child-1: expected at least 2 starts, got %d", counts[1].Load())
+	}
+}
+
+func TestCleanExitNoRestart(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int32
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "one-shot",
+			Start: func(_ context.Context) error {
+				count.Add(1)
+				return nil // clean exit — should not restart
+			},
+		},
+	}
+
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	// Allow time for any unexpected restart.
+	time.Sleep(50 * time.Millisecond)
+	sup.Stop()
+
+	if count.Load() != 1 {
+		t.Errorf("expected exactly 1 start, got %d", count.Load())
+	}
+}
+
+func TestStop(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{}, 1)
+	stopped := make(chan struct{})
+
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "blocker",
+			Start: func(ctx context.Context) error {
+				started <- struct{}{}
+				<-ctx.Done()
+				close(stopped)
+				return nil
+			},
+		},
+	}
+
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	<-started
+	sup.Stop()
+
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("child did not stop after supervisor Stop()")
+	}
+}
+
+func TestStopIdempotent(t *testing.T) {
+	t.Parallel()
+
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "noop",
+			Start: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		},
+	}
+
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	sup.Stop()
+	sup.Stop() // must not panic or deadlock
+}
+
+func ExampleStart() {
+	ready := make(chan struct{})
+	specs := []supervisor.ChildSpec{
+		{
+			Name: "worker",
+			Start: func(ctx context.Context) error {
+				close(ready)
+				<-ctx.Done()
+				return nil
+			},
+		},
+	}
+	sup := supervisor.Start(supervisor.OneForOne, specs)
+	<-ready
+	sup.Stop()
+	fmt.Println("stopped")
+	// Output:
+	// stopped
+}


### PR DESCRIPTION
## Summary

- Adds `supervisor` package with `OneForOne` and `OneForAll` restart strategies
- `ChildSpec.Start` runs in a goroutine; `nil` return = clean exit (no restart), non-nil = crash (triggers restart)
- `OneForOne` restarts only the failed child; `OneForAll` cancels all children and restarts the full set
- `Stop` cancels all children and blocks until the supervisor loop exits; safe to call multiple times

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] `make test-acc` (race detector) passes

🤖 Generated with [Claude Code](https://claude.ai/code)