### PR TITLE
fix Jekyll Liquid syntax error in docs pages

### DIFF
--- a/docs/example-app.md
+++ b/docs/example-app.md
@@ -2,6 +2,7 @@
 layout: default
 title: Example Application
 nav_order: 4
+render_with_liquid: false
 ---
 
 # Example Application

--- a/docs/functional-primitives.md
+++ b/docs/functional-primitives.md
@@ -2,6 +2,7 @@
 layout: default
 title: Functional Primitives
 nav_order: 2
+render_with_liquid: false
 ---
 
 # Functional Primitives

--- a/docs/otp-concurrency.md
+++ b/docs/otp-concurrency.md
@@ -2,6 +2,7 @@
 layout: default
 title: OTP Concurrency
 nav_order: 3
+render_with_liquid: false
 ---
 
 # OTP-Inspired Concurrency


### PR DESCRIPTION
## Problem

Jekyll's Liquid template engine interprets Go struct composite literals like `{{"Alice", 30}}` as template variables, causing a build failure:

```
Liquid syntax error (line 74): Variable '{{"Alice", 30}' was not properly terminated
```

## Fix

Add `render_with_liquid: false` to the front matter of all three docs pages. This is safe because none of them use any Liquid template tags — they contain only Markdown and fenced Go code blocks.

Applied defensively to all three pages so future Go code additions don't hit the same issue.

🤖 Generated with [Claude Code](https://claude.ai/code)