### PR TITLE
fix Jekyll Liquid error: rewrite struct literal to avoid {{ in source

### DIFF
--- a/docs/functional-primitives.md
+++ b/docs/functional-primitives.md
@@ -77,8 +77,15 @@ anyBig   := slice.Any(nums, func(n int) bool { return n > 4 })        // true
 // SortBy sorts ascending by the key function.
 sorted := slice.SortBy(nums, func(n int) int { return -n }) // [5,4,3,2,1]
 
-type Person struct{ Name string; Age int }
-people := []Person{{"Alice", 30}, {"Bob", 25}, {"Carol", 35}}
+type Person struct {
+    Name string
+    Age  int
+}
+people := []Person{
+    {Name: "Alice", Age: 30},
+    {Name: "Bob",   Age: 25},
+    {Name: "Carol", Age: 35},
+}
 youngest, _ := slice.MinBy(people, func(p Person) int { return p.Age }) // Bob
 oldest,   _ := slice.MaxBy(people, func(p Person) int { return p.Age }) // Carol
 ```


### PR DESCRIPTION
## Problem

GitHub Pages runs Jekyll 3.10. The previous fix used `render_with_liquid: false` which is a Jekyll 4+ feature and is silently ignored on 3.x, so the build still fails with:

```
Liquid syntax error (line 74): Variable '{{"Alice", 30}' was not properly terminated
```

## Fix

Rewrite the `[]Person` literal in `docs/functional-primitives.md` using named fields on separate lines. This eliminates the `{{` character sequence from the markdown source entirely — no Liquid escaping needed.

Before:
```go
people := []Person{{"Alice", 30}, {"Bob", 25}, {"Carol", 35}}
```

After:
```go
people := []Person{
    {Name: "Alice", Age: 30},
    {Name: "Bob",   Age: 25},
    {Name: "Carol", Age: 35},
}
```

🤖 Generated with [Claude Code](https://claude.ai/code)