### PR TITLE
add circuit breaker example demonstrating genserver

### DIFF
--- a/docs/example-app.md
+++ b/docs/example-app.md
@@ -1,12 +1,23 @@
 ---
 layout: default
-title: Example Application
+title: Example Applications
 nav_order: 4
 render_with_liquid: false
 ---
 
-# Example Application
+# Example Applications
 {: .no_toc }
+
+<details open markdown="block">
+  <summary>Contents</summary>
+  {: .text-delta }
+1. TOC
+{:toc}
+</details>
+
+---
+
+## Word Frequency Service
 
 [View source on GitHub](https://github.com/mikehelmick/go-functional/blob/main/examples/wordfreq/main.go){: .btn .btn-outline }
 
@@ -132,4 +143,118 @@ Top 5 words:
   and            3
 
 14 of 46 unique words appear more than once
+```
+
+---
+
+## Circuit Breaker
+
+[View source on GitHub](https://github.com/mikehelmick/go-functional/blob/main/examples/circuitbreaker/main.go){: .btn .btn-outline }
+
+`examples/circuitbreaker` implements a circuit breaker using `genserver` as the state machine. A circuit breaker stops cascading failures by fast-failing requests when a downstream dependency is unhealthy.
+
+```bash
+go run github.com/mikehelmick/go-functional/examples/circuitbreaker@latest
+```
+
+### State machine
+
+```
+Closed ──(threshold failures)──▶ Open ──(timeout elapsed)──▶ HalfOpen
+  ▲                                                               │
+  └──────────────────(success)────────────────────────────────── ┘
+                     (failure returns to Open)
+```
+
+| Mode | Behaviour |
+|---|---|
+| **Closed** | Normal operation — all requests pass through |
+| **Open** | Tripped — requests are rejected immediately (fast-fail) |
+| **HalfOpen** | Probing — one test request is allowed; success closes, failure reopens |
+
+### Why genserver fits perfectly
+
+The circuit breaker's state must be mutated atomically: reading the current mode and transitioning it must happen as a single unit. `genserver` provides this guarantee for free — `HandleCall` and `HandleCast` run serially in a single goroutine, so no mutex is needed.
+
+- **`Call(opAllow)`** — synchronous gate check; reads the mode and may transition `Open → HalfOpen`
+- **`Cast(opSuccess)` / `Cast(opFailure)`** — async outcome reports; update the failure counter and drive state transitions
+
+### Implementation
+
+```go
+type cbServer struct{ cfg Config }
+
+func (cbServer) HandleCall(req cbOp, st cbState) (bool, cbState) {
+    switch st.mode {
+    case Closed:
+        return true, st
+    case Open:
+        if time.Since(st.openedAt) >= st.cfg.Timeout {
+            st.mode = HalfOpen   // transition on first probe attempt
+            return true, st
+        }
+        return false, st
+    case HalfOpen:
+        return true, st
+    }
+    return false, st
+}
+
+func (cbServer) HandleCast(req cbOp, st cbState) cbState {
+    switch req {
+    case opSuccess:
+        if st.mode == HalfOpen {
+            st.mode, st.failures = Closed, 0
+        }
+    case opFailure:
+        st.failures++
+        if st.mode == HalfOpen || (st.mode == Closed && st.failures >= st.cfg.Threshold) {
+            st.mode, st.openedAt = Open, time.Now()
+        }
+    }
+    return st
+}
+```
+
+The public `Do` method wraps the genserver calls into a clean API:
+
+```go
+func (cb *CircuitBreaker) Do(fn func() error) error {
+    if !cb.srv.Call(opAllow) {
+        return ErrOpen
+    }
+    if err := fn(); err != nil {
+        cb.srv.Cast(opFailure)
+        return err
+    }
+    cb.srv.Cast(opSuccess)
+    return nil
+}
+```
+
+### Sample output
+
+```
+Phase 1 — normal operation (circuit closed)
+  request                      ✓ ok
+
+Phase 2 — three consecutive failures trip the breaker
+  request 1                    ✗ failed: service unavailable
+  request 2                    ✗ failed: service unavailable
+  request 3                    ✗ failed: service unavailable
+
+Phase 3 — circuit open, requests are rejected immediately
+  request 1                    ✗ rejected (circuit open)
+  request 2                    ✗ rejected (circuit open)
+  request 3                    ✗ rejected (circuit open)
+
+Phase 4 — waiting 200ms for recovery timeout...
+
+Phase 5 — half-open: probe succeeds, circuit closes
+  probe                        ✓ ok
+
+Phase 6 — normal operation resumed
+  request 1                    ✓ ok
+  request 2                    ✓ ok
+  request 3                    ✓ ok
 ```

--- a/examples/circuitbreaker/main.go
+++ b/examples/circuitbreaker/main.go
@@ -1,0 +1,214 @@
+// Copyright 2026 the go-functional authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Parts of this file were written with the assistance of Claude Code (claude.ai/code).
+
+// Command circuitbreaker demonstrates using genserver to implement a
+// circuit breaker — a resilience pattern that stops cascading failures
+// by fast-failing requests when a downstream dependency is unhealthy.
+//
+// State machine:
+//
+//	Closed ──(threshold failures)──▶ Open ──(timeout elapsed)──▶ HalfOpen
+//	  ▲                                                               │
+//	  └──────────────────(success)─────────────────────────────────── ┘
+//	                     (failure returns to Open)
+package main
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mikehelmick/go-functional/genserver"
+)
+
+// ── Mode ────────────────────────────────────────────────────────────────────
+
+// Mode is the circuit breaker's operating mode.
+type Mode int
+
+const (
+	Closed   Mode = iota // normal: all requests pass through
+	Open                 // tripped: requests are rejected immediately
+	HalfOpen             // probing: one test request is allowed through
+)
+
+func (m Mode) String() string {
+	switch m {
+	case Closed:
+		return "closed"
+	case Open:
+		return "open"
+	case HalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// ── Config ───────────────────────────────────────────────────────────────────
+
+// Config holds circuit breaker tuning parameters.
+type Config struct {
+	// Threshold is the number of consecutive failures that trip the breaker.
+	Threshold int
+	// Timeout is how long the breaker stays Open before probing with a
+	// single test request (transitioning to HalfOpen).
+	Timeout time.Duration
+}
+
+// ── GenServer state and request types ────────────────────────────────────────
+
+type cbState struct {
+	mode     Mode
+	failures int
+	openedAt time.Time
+	cfg      Config
+}
+
+type cbOp int
+
+const (
+	opAllow   cbOp = iota // Call: is the next request permitted?
+	opSuccess             // Cast: the last request succeeded
+	opFailure             // Cast: the last request failed
+)
+
+// ── Server implementation ────────────────────────────────────────────────────
+
+type cbServer struct{ cfg Config }
+
+func (s cbServer) Init() cbState {
+	return cbState{mode: Closed, cfg: s.cfg}
+}
+
+// HandleCall handles the synchronous opAllow request. It returns whether the
+// caller may proceed and the (possibly updated) state.
+func (cbServer) HandleCall(req cbOp, st cbState) (bool, cbState) {
+	switch st.mode {
+	case Closed:
+		return true, st
+	case Open:
+		// Transition to HalfOpen once the timeout has elapsed.
+		if time.Since(st.openedAt) >= st.cfg.Timeout {
+			st.mode = HalfOpen
+			return true, st
+		}
+		return false, st
+	case HalfOpen:
+		return true, st
+	}
+	return false, st
+}
+
+// HandleCast handles async outcome reports (opSuccess / opFailure).
+func (cbServer) HandleCast(req cbOp, st cbState) cbState {
+	switch req {
+	case opSuccess:
+		if st.mode == HalfOpen {
+			// Probe succeeded — close the circuit and reset the counter.
+			st.mode = Closed
+			st.failures = 0
+		}
+	case opFailure:
+		st.failures++
+		if st.mode == HalfOpen || (st.mode == Closed && st.failures >= st.cfg.Threshold) {
+			st.mode = Open
+			st.openedAt = time.Now()
+		}
+	}
+	return st
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+// ErrOpen is returned by Do when the circuit breaker is open.
+var ErrOpen = errors.New("circuit breaker open")
+
+// CircuitBreaker wraps a genserver to provide a goroutine-safe circuit breaker.
+// All state transitions are serialised through the genserver loop.
+type CircuitBreaker struct {
+	srv *genserver.GenServer[cbState, cbOp, bool]
+}
+
+// New creates and starts a CircuitBreaker with the given Config.
+func New(cfg Config) *CircuitBreaker {
+	return &CircuitBreaker{
+		srv: genserver.Start[cbState, cbOp, bool](cbServer{cfg: cfg}),
+	}
+}
+
+// Do executes fn if the circuit allows it, records the outcome, and returns
+// ErrOpen if the request was rejected because the circuit is open.
+func (cb *CircuitBreaker) Do(fn func() error) error {
+	if !cb.srv.Call(opAllow) {
+		return ErrOpen
+	}
+	if err := fn(); err != nil {
+		cb.srv.Cast(opFailure)
+		return err
+	}
+	cb.srv.Cast(opSuccess)
+	return nil
+}
+
+// Stop shuts down the underlying genserver.
+func (cb *CircuitBreaker) Stop() {
+	cb.srv.Stop()
+}
+
+// ── Demo ─────────────────────────────────────────────────────────────────────
+
+func main() {
+	cb := New(Config{Threshold: 3, Timeout: 200 * time.Millisecond})
+	defer cb.Stop()
+
+	errFlaky := errors.New("service unavailable")
+
+	report := func(label string, err error) {
+		switch {
+		case err == nil:
+			fmt.Printf("  %-28s ✓ ok\n", label)
+		case errors.Is(err, ErrOpen):
+			fmt.Printf("  %-28s ✗ rejected (circuit open)\n", label)
+		default:
+			fmt.Printf("  %-28s ✗ failed: %v\n", label, err)
+		}
+	}
+
+	fmt.Println("Phase 1 — normal operation (circuit closed)")
+	report("request", cb.Do(func() error { return nil }))
+
+	fmt.Println("\nPhase 2 — three consecutive failures trip the breaker")
+	for i := range 3 {
+		report(fmt.Sprintf("request %d", i+1), cb.Do(func() error { return errFlaky }))
+	}
+
+	fmt.Println("\nPhase 3 — circuit open, requests are rejected immediately")
+	for i := range 3 {
+		report(fmt.Sprintf("request %d", i+1), cb.Do(func() error { return nil }))
+	}
+
+	fmt.Printf("\nPhase 4 — waiting %s for recovery timeout...\n", 200*time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
+
+	fmt.Println("\nPhase 5 — half-open: probe succeeds, circuit closes")
+	report("probe", cb.Do(func() error { return nil }))
+
+	fmt.Println("\nPhase 6 — normal operation resumed")
+	for i := range 3 {
+		report(fmt.Sprintf("request %d", i+1), cb.Do(func() error { return nil }))
+	}
+}


### PR DESCRIPTION
## Summary

Adds \`examples/circuitbreaker\` — a circuit breaker built on \`genserver\`.

### Why this example works well for genserver

A circuit breaker's state (mode + failure count) must be read and written atomically. \`genserver\` provides this for free: \`HandleCall\` and \`HandleCast\` run serially in a single goroutine so no mutex is needed.

- \`Call(opAllow)\` — synchronous gate check; reads mode and may transition \`Open → HalfOpen\`
- \`Cast(opSuccess)\` / \`Cast(opFailure)\` — async outcome reports; drive the failure counter and state transitions

### State machine

\`\`\`
Closed ──(threshold failures)──▶ Open ──(timeout elapsed)──▶ HalfOpen
  ▲                                                               │
  └──────────────────(success)────────────────────────────────── ┘
\`\`\`

### Files changed

- \`examples/circuitbreaker/main.go\` — full implementation + demo
- \`docs/example-app.md\` — new circuit breaker section with walkthrough and sample output

## Test plan

- [x] \`go run ./examples/circuitbreaker/\` produces expected output
- [x] \`make test\` passes
- [x] \`make lint\` passes

🤖 Generated with [Claude Code](https://claude.ai/code)