### PR TITLE
fix: prevent integer overflow panic in Take with math.MinInt

### DIFF
--- a/slice/take.go
+++ b/slice/take.go
@@ -28,7 +28,9 @@ func Take[T any](in []T, amount int) []T {
 		return in[0:amount]
 	}
 	// negative amount, take from the end.
-	if amount*-1 >= len(in) {
+	// Use <= instead of amount*-1 to avoid signed integer overflow when
+	// amount == math.MinInt.
+	if amount <= -len(in) {
 		return in
 	}
 	return in[len(in)+amount:]

--- a/slice/take_test.go
+++ b/slice/take_test.go
@@ -16,6 +16,7 @@ package slice_test
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -84,6 +85,13 @@ func TestTake(t *testing.T) {
 			name: "negative_over",
 			in:   []int{1, 2, 3},
 			amt:  -4,
+			want: []int{1, 2, 3},
+		},
+		{
+			// math.MinInt * -1 overflows back to math.MinInt; ensure no panic.
+			name: "min_int_overflow",
+			in:   []int{1, 2, 3},
+			amt:  math.MinInt,
 			want: []int{1, 2, 3},
 		},
 	}


### PR DESCRIPTION
## Summary

- `slice.Take` with `amount == math.MinInt` previously panicked with a slice bounds error
- The expression `amount * -1` wraps back to `math.MinInt` due to signed integer overflow
- The overflow caused the subsequent `in[len(in)+amount:]` index to be hugely negative, triggering a runtime panic
- Replaced the multiplication with `amount <= -len(in)`, which avoids overflow entirely and preserves identical behaviour for all other inputs
- Added a regression test case `min_int_overflow` to `TestTake`

## Security impact

In a server context where `Take` is called with user-controlled input, this panic is a denial-of-service vector. No other packages in this module are affected.

## Test plan

- [ ] `make test` passes (all packages)
- [ ] New test case `TestTake/min_int_overflow` exercises the previously panicking path

🤖 Generated with [Claude Code](https://claude.com/claude-code)